### PR TITLE
fix incompatibility with ilp-plugin-payment-channel-framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "greenlock": "^2.1.16",
     "ilp-packet": "^1.3.0",
     "ilp-plugin-ethereum": "github:interledgerjs/ilp-plugin-ethereum",
-    "ilp-plugin-payment-channel-framework": "github:interledgerjs/ilp-plugin-payment-channel-framework#mj-protocoldata",
+    "ilp-plugin-payment-channel-framework": "github:interledgerjs/ilp-plugin-payment-channel-framework",
     "ilp-plugin-xrp-escrow": "github:michielbdejong/ilp-plugin-xrp-escrow",
     "node-fetch": "^1.7.3",
     "uint64be": "^2.0.1"

--- a/src/pluginFactory.js
+++ b/src/pluginFactory.js
@@ -71,7 +71,7 @@ const URL_PATH_PART_VERSION = 2
 const URL_PATH_PART_NAME = 3
 const URL_PATH_PART_TOKEN = 4
 
-const WELCOME_TEXT = 'This is a BTP server, please upgrade to WebSockets.'
+const WELCOME_TEXT = '<a href="https://github.com/interledgerjs/amundsen"><h2>This is a BTP server, please upgrade to WebSockets.</h2><img src="https://oceanwide-4579.kxcdn.com/uploads/media-dynamic/cache/jpg_optimize/uploads/media/default/0001/09/thumb_8845_default_1600.jpeg"></a>'
 const LE_ROOT = '~/letsencrypt'
 const HTTP_REDIRECT_PORT = 80
 const HTTPS_PORT = 443
@@ -110,6 +110,7 @@ function getLetsEncryptServers (domain, email) {
         cert: certs.cert,
         ca: certs.chain
       }, (req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/html' })
         res.end(WELCOME_TEXT)
       })
       httpsServer.listen(HTTPS_PORT, (err) => {

--- a/src/request-handler.js
+++ b/src/request-handler.js
@@ -2,15 +2,18 @@ const IlpPacket = require('ilp-packet')
 const uuid = require('uuid/v4')
 function base64url (buf) { return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '') }
 
-function toLpi(packet, msg) {
-  return {
+function toLpi(packet, custom, msg) {
+  let obj = {
     id: uuid(),
     from: msg.to,
     to: msg.from,
     ledger: msg.ledger,
-    ilp: base64url(packet),
-    custom: {}
+    custom
   }
+  if (packet) {
+    obj.ilp = base64url(packet)
+  }
+  return obj
 }
 
 class RequestHandler {
@@ -20,16 +23,20 @@ class RequestHandler {
 
   onPlugin (prefix) {
     this.main.getPlugin(prefix).registerRequestHandler(msg => {
-      const ilpReq = IlpPacket.deserializeIlpPacket(Buffer.from(msg.ilp, 'base64'))
-      switch (ilpReq.typeString) {
-        case 'ilqp_by_source_request':
-          return this.main.quoter.answerBySource(ilpReq.data).then(ilpRes => toLpi(IlpPacket.serializeIlqpBySourceResponse(ilpRes), msg))
-        case 'ilqp_by_destination_request':
-          return this.main.quoter.answerByDest(ilpReq.data).then(ilpRes => toLpi(IlpPacket.serializeIlqpByDestinationResponse(ilpRes), msg))
-        case 'ilqp_liquidity_request':
-          return this.main.quoter.answerLiquidity(ilpReq.data).then(ilpRes => toLpi(IlpPacket.serializeIlqpLiquidityResponse(ilpRes), msg))
+      if (msg.ilp) {
+        const ilpReq = IlpPacket.deserializeIlpPacket(Buffer.from(msg.ilp, 'base64'))
+        switch (ilpReq.typeString) {
+          case 'ilqp_by_source_request':
+            return this.main.quoter.answerBySource(ilpReq.data).then(ilpRes => toLpi(IlpPacket.serializeIlqpBySourceResponse(ilpRes), {}, msg))
+          case 'ilqp_by_destination_request':
+            return this.main.quoter.answerByDest(ilpReq.data).then(ilpRes => toLpi(IlpPacket.serializeIlqpByDestinationResponse(ilpRes), {}, msg))
+          case 'ilqp_liquidity_request':
+            return this.main.quoter.answerLiquidity(ilpReq.data).then(ilpRes => toLpi(IlpPacket.serializeIlqpLiquidityResponse(ilpRes), {}, msg))
+        }
+      } else if (msg.custom) {
+        return Promise.resolve(toLpi(undefined, { error: 'not implemented yet' }, msg))
       }
-      return Promise.resolve()
+      return Promise.resolve(toLpi(undefined, { error: 'request had neither ilp nor custom' }, msg))
     })
   }
 }

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,0 +1,38 @@
+const assert = require('chai').assert
+
+const uuid = require('uuid/v4')
+const PluginDummy = require('./helpers/dummyPlugin')
+const WebSocket = require('ws')
+
+const IlpPacket = require('ilp-packet')
+const BtpPacket = require('btp-packet')
+
+const TestnetNode = require('../src/index')
+
+const HostedLedgerPlugin = require('ilp-plugin-payment-channel-framework')
+
+describe('Connect ilp-plu-pay-cha-fra to 17q4 interface', function () {
+  beforeEach(function () {
+    this.testnetNode = new TestnetNode({
+      btp: {
+        listen: 8100,
+        initialBalancePerPeer: 10000,
+        baseLedger: 'test.amundsen.',
+        authCheck: function (username, token) {
+          return (username === 'foo' && token === 'bar')
+        }
+      }
+    })
+    this.plugin = new HostedLedgerPlugin({
+      server: `btp+ws://foo:bar@localhost:8100/api/17q4`
+    })
+  })
+  it('should connect and disconnect', function() {
+    return this.testnetNode.start().then(() => {
+      return this.plugin.connect()
+    }).then(() => {
+      return this.plugin.disconnect()
+    })
+  })
+})
+


### PR DESCRIPTION
Ran into this while writing the IToT tutorial. `npm test` now points to an incompatibility with the latest master branch of ilp-plugin-payment-channel-framework.